### PR TITLE
Added support for *RangeShift operations in BigNestedIntArray

### DIFF
--- a/bobo-browse/src/main/java/com/browseengine/bobo/api/BoboIndexReader.java
+++ b/bobo-browse/src/main/java/com/browseengine/bobo/api/BoboIndexReader.java
@@ -567,6 +567,17 @@ public class BoboIndexReader extends FilterIndexReader
                             boolean useSubReaders) throws IOException
   {
     super(useSubReaders ? new MultiReader(createSubReaders(reader, workArea), false) : reader);
+    _runtimeFacetHandlerFactories = facetHandlerFactories;
+    _runtimeFacetHandlerFactoryMap = new HashMap<String,RuntimeFacetHandlerFactory<?,?>>();
+    if (_runtimeFacetHandlerFactories!=null)
+    {
+      for(RuntimeFacetHandlerFactory<?,?> factory : _runtimeFacetHandlerFactories)
+      {
+        _runtimeFacetHandlerFactoryMap.put(factory.getName(), factory);
+      }
+    }
+    _facetHandlers = facetHandlers;
+    _workArea = workArea;
     if(useSubReaders)
     {
       _dir = reader.directory();
@@ -581,23 +592,17 @@ public class BoboIndexReader extends FilterIndexReader
         {
           _subReaders[i]._dir = _dir;
           if(facetHandlers != null) _subReaders[i].setFacetHandlers(facetHandlers);
+          if (facetHandlerFactories != null)
+          {
+            _subReaders[i]._runtimeFacetHandlerFactories = _runtimeFacetHandlerFactories;
+            _subReaders[i]._runtimeFacetHandlerFactoryMap = _runtimeFacetHandlerFactoryMap;
+          }
           _starts[i] = maxDoc;
           maxDoc += _subReaders[i].maxDoc();
         }
         _starts[_subReaders.length] = maxDoc;
       }
     }
-    _runtimeFacetHandlerFactories = facetHandlerFactories;
-    _runtimeFacetHandlerFactoryMap = new HashMap<String,RuntimeFacetHandlerFactory<?,?>>();
-    if (_runtimeFacetHandlerFactories!=null)
-    {
-      for(RuntimeFacetHandlerFactory<?,?> factory : _runtimeFacetHandlerFactories)
-      {
-        _runtimeFacetHandlerFactoryMap.put(factory.getName(), factory);
-      }
-    }
-    _facetHandlers = facetHandlers;
-    _workArea = workArea;
   }
 
   protected void facetInit() throws IOException


### PR DESCRIPTION
1. Added support for *RangeShift operations in BigNestedIntArray
2. Removed unused memory manager in facet collector (all code is commented anyway). Performance tests also show that JVM memory allocation for count arrays is always superior in performance to a managed pool
3. Pass runtime facets to SubBrowser (apparently this code was never used before). It's needed to simplify unit tests. 
